### PR TITLE
Fix: dedicated heartbeat task (prevent healthcheck restart loop)

### DIFF
--- a/apps/schedule_functions.py
+++ b/apps/schedule_functions.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from apps.collect_time import generate_time_list
 from apps.parse_functions import get_ntk_quantity
-from bot import db
 from config import cnfg
 
 logger = logging.getLogger(__name__)
@@ -19,12 +18,25 @@ def _touch_heartbeat() -> None:
         logger.exception("Failed to update heartbeat file")
 
 
+async def heartbeat_loop(interval_seconds: float = 30) -> None:
+    """Refresh the liveness file on a fixed cadence, independent of collection.
+
+    The collection loop sleeps for ~19 minutes after each sample, far longer
+    than the container healthcheck window, so liveness cannot be tied to it.
+    This dedicated loop keeps the heartbeat fresh whenever the event loop runs.
+    """
+    while True:
+        _touch_heartbeat()
+        await asyncio.sleep(interval_seconds)
+
+
 async def receive_ntk_data(delta_minutes: int = 20) -> None:
     """Collect occupancy data from the NTK website every ``delta_minutes``."""
+    from bot import db  # local import avoids a circular import at module load
+
     time_list = await generate_time_list(delta_minutes=delta_minutes)
 
     while True:
-        _touch_heartbeat()
         current_time = datetime.now().strftime("%H:%M")
         if current_time in time_list:
             try:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -3,7 +3,7 @@ import logging
 
 from aiogram import Bot, Dispatcher
 
-from apps.schedule_functions import receive_ntk_data
+from apps.schedule_functions import heartbeat_loop, receive_ntk_data
 from bot import db
 from bot.handlers import router
 from config import INSTRUCTIONS_PATH, cnfg
@@ -25,8 +25,10 @@ async def on_startup(bot: Bot) -> None:
             INSTRUCTIONS_PATH,
         )
 
-    # Train the models and collect occupancy data in the background so that
-    # polling starts immediately instead of blocking on model training.
+    # Keep the liveness heartbeat fresh regardless of the collection loop's
+    # long post-sample sleep, then train models and collect data in the
+    # background so polling starts immediately.
+    asyncio.create_task(heartbeat_loop())
     asyncio.create_task(predictModels.learn_models())
     asyncio.create_task(receive_ntk_data(cnfg.DELTA_TIME_FOR_RECIEVE_NTK))
 

--- a/tests/apps/test_heartbeat.py
+++ b/tests/apps/test_heartbeat.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import pytest
+
+from apps import schedule_functions
+
+
+def test_touch_heartbeat_creates_file(tmp_path, monkeypatch):
+    hb = tmp_path / "heartbeat"
+    monkeypatch.setattr(schedule_functions.cnfg, "HEARTBEAT_PATH", str(hb))
+    schedule_functions._touch_heartbeat()
+    assert hb.exists()
+
+
+def test_touch_heartbeat_swallows_oserror(monkeypatch):
+    # A bad path must not raise — liveness updates can never crash the loop.
+    monkeypatch.setattr(schedule_functions.cnfg, "HEARTBEAT_PATH", "/nonexistent-dir/hb")
+    schedule_functions._touch_heartbeat()  # should not raise
+
+
+async def test_heartbeat_loop_refreshes_then_can_be_cancelled(tmp_path, monkeypatch):
+    hb = tmp_path / "heartbeat"
+    monkeypatch.setattr(schedule_functions.cnfg, "HEARTBEAT_PATH", str(hb))
+    task = asyncio.create_task(schedule_functions.heartbeat_loop(interval_seconds=0.01))
+    await asyncio.sleep(0.03)
+    assert hb.exists()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Problem (caught in live production verification)
The liveness heartbeat was touched only inside `receive_ntk_data`'s loop, but that loop sleeps `delta*60-60` ≈ **19 min** after each sample — far longer than the 180s healthcheck window. So after every collection the heartbeat went stale and the container would be marked unhealthy and restarted each cycle.

## Fix
- Move the heartbeat into a dedicated `heartbeat_loop()` (30s cadence) started in `on_startup`, independent of the collection loop.
- `apps/schedule_functions.py` now imports `bot.db` locally inside `receive_ntk_data` (matches `predictModels`/`plot_functions`), avoiding a circular import when the module is imported first.
- Tests: heartbeat helper creates the file, swallows OSError, and the loop refreshes then cancels cleanly.

17 tests pass; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)