### PR TITLE
Fix: container timezone (Europe/Prague) + drop dead channel id

### DIFF
--- a/bot/filters.py
+++ b/bot/filters.py
@@ -20,7 +20,6 @@ class NTKChatFilter(BaseFilter):
         return message.chat.id in [
             cnfg.ID_NTK_BIG_CHAT,
             cnfg.ID_NTK_SMALL_CHAT,
-            cnfg.ID_NTK_CHANNEL,
         ]
 
 

--- a/config.py
+++ b/config.py
@@ -37,7 +37,6 @@ class Config:
 
     ID_NTK_BIG_CHAT: int = -1001684546093
     ID_NTK_SMALL_CHAT: int = -1001384533622
-    ID_NTK_CHANNEL: int = -1001918057675
     SUPER_ADMINS: list[int] = [
         int(id_admin)
         for id_admin in config("SUPER_ADMINS", cast=str, default="").split(",")

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -14,9 +14,15 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH=/app \
     MPLBACKEND=Agg \
     PYTHONUNBUFFERED=1 \
-    DATA_DIR=/data
+    DATA_DIR=/data \
+    TZ=Europe/Prague
 WORKDIR /app
-RUN useradd -m -u 10001 bot && mkdir -p /data && chown bot:bot /data
+# tzdata + TZ make datetime.now() local to Prague (CEST), matching the legacy
+# server's timezone so collected timestamps stay continuous with history.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -u 10001 bot && mkdir -p /data && chown bot:bot /data
 COPY --from=builder --chown=bot:bot /app /app
 USER bot
 VOLUME ["/data"]


### PR DESCRIPTION
## Why
During the production cutover three small issues surfaced while verifying the live bot:

1. **Timezone.** The container ran in **UTC**, but the legacy server (poryadok) and therefore all ~105k historical occupancy timestamps were **Europe/Berlin (+02:00 / CEST)**. `datetime.now()` was labelling new rows **2h early**, breaking continuity with history and shifting the `08:00–02:00` collection window by 2h.
2. **Dead chat id.** `ID_NTK_CHANNEL = -1001918057675` returns `chat not found` from the Telegram API — the channel no longer exists. The `NTKChatFilter` entry was dead config.

## What
- Install `tzdata` and set `ENV TZ=Europe/Prague` in the runtime image so `datetime.now()` (DB timestamps) and the collection window match the historical CEST convention.
- Remove `ID_NTK_CHANNEL` from `config.py` and `bot/filters.py`.

## Data note (handled out-of-band)
The cutover-evening rows that the UTC container already wrote (2026-06-09 19:20 → 2026-06-10 02:00) are being corrected +2h directly on the live SQLite volume, so the series stays continuous and de-interleaved. No code change needed for that.

## Verification
- `ruff format --check`, `ruff check`, `ty check`: clean
- `pytest`: 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)