### PR TITLE
fix(digest): never repost on a failed edit (no more duplicate messages)

### DIFF
--- a/apps/schedule_functions.py
+++ b/apps/schedule_functions.py
@@ -78,66 +78,82 @@ async def daily_maintenance_loop(interval_seconds: float = 24 * 60 * 60) -> None
         await asyncio.sleep(interval_seconds)
 
 
-async def morning_digest_loop(bot, interval_seconds: float = 60) -> None:
-    """Post / refresh / delete the daily occupancy digest.
+async def _digest_tick(bot, now: datetime) -> None:
+    """Run one digest iteration: re-derive the action from the clock + stored
+    state and post / refresh / delete accordingly.
 
-    Time-driven and restart-safe: state lives in SQLite, so every tick simply
-    re-derives the right action from the clock. No-op unless DIGEST_ENABLED.
+    Restart-safe: state lives in SQLite, so the action is a pure function of the
+    current time and the persisted row.
     """
-    if not cnfg.DIGEST_ENABLED:
-        logger.info("Morning digest disabled (DIGEST_ENABLED is off)")
-        return
-
     from datetime import date
 
+    from aiogram.exceptions import TelegramBadRequest
     from aiogram.types import BufferedInputFile, InputMediaPhoto
 
     from apps.digest import DigestAction, DigestState, decide_digest_action, render
     from bot import db
 
-    while True:
-        try:
-            now = datetime.now()
-            row = db.get_digest_state()
-            state = DigestState(date.fromisoformat(row[0]), row[1], row[2], row[3]) if row else None
-            action = decide_digest_action(now, state)
+    row = db.get_digest_state()
+    state = DigestState(date.fromisoformat(row[0]), row[1], row[2], row[3]) if row else None
+    action = decide_digest_action(now, state)
 
-            if action is DigestAction.POST:
-                image, caption = await render(now)
-                message = await bot.send_photo(
-                    cnfg.DIGEST_CHAT_ID,
-                    BufferedInputFile(image, "ntk.png"),
+    if action is DigestAction.POST:
+        image, caption = await render(now)
+        message = await bot.send_photo(
+            cnfg.DIGEST_CHAT_ID,
+            BufferedInputFile(image, "ntk.png"),
+            caption=caption,
+            parse_mode="HTML",
+        )
+        db.save_digest_state(
+            now.date().isoformat(), cnfg.DIGEST_CHAT_ID, message.message_id, now.hour
+        )
+    elif action is DigestAction.UPDATE and state is not None:
+        image, caption = await render(now)
+        try:
+            await bot.edit_message_media(
+                chat_id=state.chat_id,
+                message_id=state.message_id,
+                media=InputMediaPhoto(
+                    media=BufferedInputFile(image, "ntk.png"),
                     caption=caption,
                     parse_mode="HTML",
-                )
-                db.save_digest_state(
-                    now.date().isoformat(), cnfg.DIGEST_CHAT_ID, message.message_id, now.hour
-                )
-            elif action is DigestAction.UPDATE and state is not None:
-                image, caption = await render(now)
-                try:
-                    await bot.edit_message_media(
-                        chat_id=state.chat_id,
-                        message_id=state.message_id,
-                        media=InputMediaPhoto(
-                            media=BufferedInputFile(image, "ntk.png"),
-                            caption=caption,
-                            parse_mode="HTML",
-                        ),
-                    )
-                    db.save_digest_state(
-                        state.post_date.isoformat(), state.chat_id, state.message_id, now.hour
-                    )
-                except Exception:
-                    logger.exception("Digest update failed; forgetting the message")
-                    db.clear_digest_state()
-            elif action is DigestAction.DELETE and state is not None:
-                try:
-                    await bot.delete_message(state.chat_id, state.message_id)
-                except Exception:
-                    logger.exception("Digest delete failed; forgetting the message anyway")
-                finally:
-                    db.clear_digest_state()
+                ),
+            )
+        except TelegramBadRequest as exc:
+            # "message is not modified" is benign (two identical renders); any
+            # other bad request means the message is gone or unreachable. In
+            # NEITHER case do we repost — re-posting would duplicate the digest,
+            # which is exactly the bug we are avoiding. Keep the state and mark
+            # this hour done so we don't retry the same edit every tick.
+            if "not modified" not in str(exc).lower():
+                logger.warning("Digest edit failed; keeping existing message: %s", exc)
+        # Transient (e.g. network) errors propagate to the caller's handler so
+        # the hour is NOT marked done and the edit is retried on the next tick.
+        db.save_digest_state(
+            state.post_date.isoformat(), state.chat_id, state.message_id, now.hour
+        )
+    elif action is DigestAction.DELETE and state is not None:
+        try:
+            await bot.delete_message(state.chat_id, state.message_id)
+        except Exception:
+            logger.exception("Digest delete failed; forgetting the message anyway")
+        finally:
+            db.clear_digest_state()
+
+
+async def morning_digest_loop(bot, interval_seconds: float = 60) -> None:
+    """Post / refresh / delete the daily occupancy digest.
+
+    Time-driven and restart-safe. No-op unless DIGEST_ENABLED.
+    """
+    if not cnfg.DIGEST_ENABLED:
+        logger.info("Morning digest disabled (DIGEST_ENABLED is off)")
+        return
+
+    while True:
+        try:
+            await _digest_tick(bot, datetime.now())
         except Exception:
             logger.exception("Morning digest tick failed")
         await asyncio.sleep(interval_seconds)

--- a/tests/apps/test_digest_loop.py
+++ b/tests/apps/test_digest_loop.py
@@ -1,0 +1,90 @@
+"""Loop-level digest tests: a failed hourly edit must never produce a second
+message. Regression guard for the "digest posts twice instead of updating" bug.
+"""
+
+import asyncio
+from datetime import datetime
+
+import pytest
+from aiogram.exceptions import TelegramBadRequest
+
+from apps import schedule_functions
+from config import cnfg
+
+
+class FakeMessage:
+    message_id = 42
+
+
+class FakeBot:
+    """Records calls; ``edit_message_media`` can be told to raise."""
+
+    def __init__(self, edit_error: Exception | None = None):
+        self.edit_error = edit_error
+        self.send_calls = 0
+        self.edit_calls = 0
+        self.delete_calls = 0
+
+    async def send_photo(self, *args, **kwargs):
+        self.send_calls += 1
+        return FakeMessage()
+
+    async def edit_message_media(self, *args, **kwargs):
+        self.edit_calls += 1
+        if self.edit_error is not None:
+            raise self.edit_error
+
+    async def delete_message(self, *args, **kwargs):
+        self.delete_calls += 1
+
+
+@pytest.fixture
+def digest_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(cnfg, "DB_PATH", str(tmp_path / "ntk.sqlite"))
+    monkeypatch.setattr(cnfg, "DIGEST_CHAT_ID", -100)
+
+    async def fake_render(now):
+        return b"png-bytes", "caption"
+
+    monkeypatch.setattr("apps.digest.render", fake_render)
+
+    from bot import db
+
+    db.init_db()
+    return db
+
+
+def test_post_then_update_uses_a_single_message(digest_db):
+    """Happy path: post once, then refresh the same message — never a 2nd send."""
+    bot = FakeBot()
+
+    asyncio.run(schedule_functions._digest_tick(bot, datetime(2024, 3, 4, 6, 50)))
+    assert bot.send_calls == 1
+    assert digest_db.get_digest_state() == ("2024-03-04", -100, 42, 6)
+
+    asyncio.run(schedule_functions._digest_tick(bot, datetime(2024, 3, 4, 7, 5)))
+    assert bot.send_calls == 1  # still one message
+    assert bot.edit_calls == 1
+    assert digest_db.get_digest_state() == ("2024-03-04", -100, 42, 7)
+
+
+def test_edit_not_modified_does_not_repost(digest_db):
+    """The bug: an edit that fails with 'message is not modified' must NOT cause
+    the digest to be re-posted on the following tick."""
+    err = TelegramBadRequest(method=None, message="Bad Request: message is not modified")
+    bot = FakeBot(edit_error=err)
+
+    # Post the first message.
+    asyncio.run(schedule_functions._digest_tick(bot, datetime(2024, 3, 4, 6, 50)))
+    assert bot.send_calls == 1
+
+    # Hour advances → UPDATE → edit raises "not modified".
+    asyncio.run(schedule_functions._digest_tick(bot, datetime(2024, 3, 4, 7, 5)))
+    assert bot.edit_calls == 1
+
+    # State must survive so the next tick does NOT see ``None`` and re-post.
+    assert digest_db.get_digest_state() is not None
+
+    # Next tick inside the window: there must be no second message.
+    asyncio.run(schedule_functions._digest_tick(bot, datetime(2024, 3, 4, 7, 6)))
+    assert bot.send_calls == 1, "digest was re-posted instead of updated"


### PR DESCRIPTION
## Bug

The morning digest sent **two messages** instead of posting one and updating it hourly.

## Root cause

In `apps/schedule_functions.py`, the `UPDATE` branch ran `db.clear_digest_state()` on **any** `edit_message_media` failure. Once the state was cleared, the next tick — still inside the 06:45–16:00 window — saw `state is None` and took the `POST` path, sending a brand-new photo.

The usual trigger is Telegram's benign `TelegramBadRequest: message is not modified`, raised when two consecutive hourly renders are identical (e.g. early morning before fresh occupancy data arrives).

## Fix

- Extracted the per-tick logic into a testable `_digest_tick(bot, now)` coroutine; the loop is now a thin wrapper.
- `UPDATE` no longer clears state / reposts on failure. It catches `TelegramBadRequest` (treating "not modified" as a no-op, logging anything else) and always marks the hour done. Transient errors (e.g. network) propagate so the edit is retried next tick rather than duplicating the message.

## Tests

- New `tests/apps/test_digest_loop.py` covers the happy path and the not-modified regression. Verified RED against the buggy code, GREEN after the fix.
- Full suite: **45 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)